### PR TITLE
Add purchase amount features

### DIFF
--- a/elo_loyalty_prediction.ipynb
+++ b/elo_loyalty_prediction.ipynb
@@ -47,38 +47,10 @@
    "outputs": [],
    "source": [
     "hist_trans_df = pd.read_csv('data/unzipped/historical_transactions.csv')\n",
-    "merchants_df = pd.read_csv('data/unzipped/merchants.csv')\n",
+    "merchants_df = pd.read_csv('data/unzipped/merchants.csv', index_col='merchant_id')\n",
     "merch_trans_df = pd.read_csv('data/unzipped/new_merchant_transactions.csv')\n",
-    "train_and_validation_df = pd.read_csv('data/unzipped/train.csv')\n",
-    "test_df = pd.read_csv('data/unzipped/test.csv')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.model_selection import train_test_split\n",
-    "train_df, validate_df = train_test_split(train_and_validation_df, test_size=0.2, random_state=238923)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_df.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "validate_df.shape"
+    "train_and_validation_df = pd.read_csv('data/unzipped/train.csv', index_col='card_id')\n",
+    "test_df = pd.read_csv('data/unzipped/test.csv', index_col='card_id')"
    ]
   },
   {
@@ -106,6 +78,100 @@
    "outputs": [],
    "source": [
     "merch_trans_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_and_validation_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Features\n",
+    "\n",
+    "Next we want to combine and shape all of our raw data to create useful features in the train data set.\n",
+    "\n",
+    "For now, I'll do this step-by-step here to make it a bit easier to understand (for myself), but later we'll probably want to do this in some python classes, or this file will be huge. // Erich"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merged = train_and_validation_df.merge(hist_trans_df, how='left', on=['card_id']); merged.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "means = merged.groupby('card_id')['purchase_amount'].mean(); means.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sums = merged.groupby('card_id')['purchase_amount'].sum(); sums.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_and_validation_df['purchase_amount_mean'] = means\n",
+    "train_and_validation_df['purchase_amount_sum'] = sums"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Split Into Train and Validation Sets\n",
+    "\n",
+    "Split our data into a train test (80%) and a validation set (20%)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "train_df, validate_df = train_test_split(train_and_validation_df, test_size=0.3, random_state=238923)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validate_df.shape"
    ]
   },
   {
@@ -184,7 +250,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sns.distplot(hist_trans_df.purchase_amount)"
+    "sns.distplot(train_df.purchase_amount_mean)"
    ]
   },
   {
@@ -226,7 +292,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "valid_idx = range(len(train_and_validation_df) - len(validate_df), len(train_and_validation_df))"
+    "valid_idx = range(len(train_and_validation_df) - len(validate_df), len(train_and_validation_df)); valid_idx"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we picked our validation samples randomly from the initial data set, and since fastai requires us to give the indices of the validation samples in a data frame containing both the training and validation samples, we just concatenate them together with training samples first and the validation samples at the end."
    ]
   },
   {
@@ -236,7 +309,7 @@
    "outputs": [],
    "source": [
     "category_names = ['feature_1', 'feature_2', 'feature_3']\n",
-    "continuous_names = []\n",
+    "continuous_names = ['purchase_amount_mean', 'purchase_amount_sum']\n",
     "dep_var = 'target'"
    ]
   },
@@ -246,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_df[dep_var].head()"
+    "df = pd.concat([train_df, validate_df]).reset_index()[category_names + continuous_names + [dep_var]]"
    ]
   },
   {
@@ -255,7 +328,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = (TabularList.from_df(train_and_validation_df,\n",
+    "data = (TabularList.from_df(df,\n",
     "                            path='data/unzipped',\n",
     "                            cat_names=category_names,\n",
     "                            cont_names=continuous_names,\n",
@@ -299,18 +372,7 @@
    "outputs": [],
    "source": [
     "max_log_y = np.log(np.max(train_df['target']) * 1.2)\n",
-    "y_range = torch.tensor([0, max_log_y], device=defaults.device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def rmse(pred:Tensor, targ:Tensor)->Rank0Tensor:\n",
-    "    \"Root mean squared error between `pred` and `targ`.\"\n",
-    "    return torch.sqrt(F.mse_loss(pred, targ))"
+    "y_range = torch.tensor([-max_log_y, max_log_y], device=defaults.device); y_range"
    ]
   },
   {
@@ -379,7 +441,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn.fit_one_cycle(1, 1e-5, wd=0.2)"
+    "learn.fit_one_cycle(1, 1e-6, wd=0.2)"
    ]
   },
   {
@@ -415,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ pandas
 numpy
 seaborn
 sklearn
+torch
+torchvision
+torchvision-nightly
 


### PR DESCRIPTION
In this PR, I do a number of things.

First of all, as @boris-tschirschwitz pointed out, although we were splitting our data into a test and a validation set properly, we weren't giving the fastai model the correct indices defining which are the train and which are the validation samples. That has been fixed.

Second, to make things easier, I'm now importing some of the tables with their natural ids (e.g. `card_id`) as actual index columns in pandas.

Third, I added two new feature columns – `purchase_amount_mean` and `purchase_amount_sum`. Each of these consists of aggregated data from the historical transactions table. They represent the mean purchase amount for all the transactions with any given card, and the sum of all purchase amounts for any given card, respectively.

Fourth, I set a more sensible range within which we want the model to make predictions; I'll explain this on Thursday.