### PR TITLE
Aggregate more columns in more ways from the historical transactions.

### DIFF
--- a/elo_loyalty_prediction.ipynb
+++ b/elo_loyalty_prediction.ipynb
@@ -76,6 +76,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "for v in ['authorized_flag', 'category_1', 'category_2', 'category_3', 'merchant_id', 'merchant_category_id',\n",
+    "          'subsector_id', 'city_id', 'state_id']:\n",
+    "    hist_trans_df[v] = hist_trans_df[v].astype('category').cat.as_ordered()\n",
+    "    merch_trans_df[v] = merch_trans_df[v].astype('category').cat.as_ordered()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hist_trans_df.head()"
    ]
   },
@@ -122,6 +134,8 @@
    "outputs": [],
    "source": [
     "from fastai import *\n",
+    "from fastai.tabular import *\n",
+    "from fastai.metrics import *\n",
     "from feature_engineering import *"
    ]
   },
@@ -153,7 +167,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next we'll use the functions defined in `feature_engineering.py` to aggregate the historical transactions for each card into single values for that card, for instance the mean of all purchase amounts, &c."
+    "Next we'll use the functions defined in `feature_engineering.py` to aggregate the historical transactions for each card into single values for that card, for instance the mean of all purchase amounts, &c.\n",
+    "\n",
+    "_Note: these functions can take quite a long time to complete._"
    ]
   },
   {
@@ -162,10 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_aggregated_numerical_fields(train_and_validation_df,\n",
-    "                                hist_trans_df,\n",
-    "                                column_names=['purchase_amount', 'installments', 'month_lag'],\n",
-    "                                aggregator=np.mean)"
+    "hist_trans_df.columns"
    ]
   },
   {
@@ -174,10 +187,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_aggregated_numerical_fields(train_and_validation_df,\n",
-    "                                hist_trans_df,\n",
-    "                                column_names=['purchase_amount', 'installments'],\n",
-    "                                aggregator=np.sum)"
+    "aggregators = {\n",
+    "    'purchase_amount': ['sum', 'mean', 'min', 'max', 'std'],\n",
+    "    'installments': ['sum', 'mean', 'min', 'max', 'std'],\n",
+    "    'month_lag': ['mean', 'min', 'max'],\n",
+    "    'merchant_id': ['nunique'],\n",
+    "    'merchant_category_id': ['nunique'],\n",
+    "    'state_id': ['nunique'],\n",
+    "    'city_id': ['nunique'],\n",
+    "    'subsector_id': ['nunique'],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "add_aggregated_numerical_fields(train_and_validation_df, hist_trans_df, aggregators=aggregators)"
    ]
   },
   {
@@ -204,6 +232,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# category_2 and category_3 contain nan values, so let's skip those for now.\n",
+    "add_top_categories(train_and_validation_df,\n",
+    "                   hist_trans_df,\n",
+    "                   column_names=['authorized_flag', 'category_1', 'subsector_id', 'city_id', 'state_id'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "train_and_validation_df.head()"
    ]
   },
@@ -220,17 +260,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_aggregated_numerical_fields(test_df,\n",
-    "                                hist_trans_df,\n",
-    "                                column_names=['purchase_amount', 'installments', 'month_lag'],\n",
-    "                                aggregator=np.mean)\n",
-    "add_aggregated_numerical_fields(test_df,\n",
-    "                                hist_trans_df,\n",
-    "                                column_names=['purchase_amount', 'installments'],\n",
-    "                                aggregator=np.sum)\n",
+    "add_aggregated_numerical_fields(test_df, hist_trans_df, aggregators=aggregators)\n",
     "add_aggregated_categorical_fields(test_df,\n",
     "                                  hist_trans_df,\n",
-    "                                  column_names=['authorized_flag', 'category_1', 'category_2', 'category_3'])"
+    "                                  column_names=['authorized_flag', 'category_1', 'category_2', 'category_3'])\n",
+    "# category_2 and category_3 contain nan values, so let's skip those for now.\n",
+    "add_top_categories(test_df,\n",
+    "                   hist_trans_df,\n",
+    "                   column_names=['authorized_flag', 'category_1', 'subsector_id', 'city_id', 'state_id'])"
    ]
   },
   {
@@ -304,6 +341,15 @@
     "## Explore Data\n",
     "\n",
     "### Correlations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df.corr().target.sort_values(ascending=False)"
    ]
   },
   {
@@ -391,17 +437,7 @@
    "source": [
     "## Set Up Model\n",
     "\n",
-    "We'll use the fastai tabular regressor, for which we'll need some additional imports."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from fastai.tabular import *\n",
-    "from fastai.metrics import *"
+    "We'll use the fastai tabular regressor here, which is built for exactly this problem."
    ]
   },
   {
@@ -430,7 +466,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Puh, we have quite a lot of continuous features now. Rather than writing out all of them, let's just take all the columns and then subtract those that are _not_ continuous."
+    "Let's have a look at which columns we have. We will need to tell fastai which ones are categorical and which ones are continuous."
    ]
   },
   {
@@ -439,10 +475,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "category_names = ['feature_1', 'feature_2', 'feature_3']\n",
-    "dep_var = 'target'\n",
-    "continuous_names = [col for col in train_df.columns if col not in (\n",
-    "    ['first_active_month'] + category_names + [dep_var])]"
+    "train_df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "category_names = ['feature_1',\n",
+    "                  'feature_2',\n",
+    "                  'feature_3',\n",
+    "                  'authorized_flag_top',\n",
+    "                  'category_1_top',\n",
+    "                  'subsector_id_top',\n",
+    "                  'city_id_top',\n",
+    "                  'state_id_top']\n",
+    "continuous_names = ['purchase_amount_sum',\n",
+    "                    'purchase_amount_mean',\n",
+    "                    'purchase_amount_min',\n",
+    "                    'purchase_amount_max',\n",
+    "                    'purchase_amount_std',\n",
+    "                    'installments_sum',\n",
+    "                    'installments_mean',\n",
+    "                    'installments_min',\n",
+    "                    'installments_max',\n",
+    "                    'installments_std',\n",
+    "                    'month_lag_mean',\n",
+    "                    'month_lag_min',\n",
+    "                    'month_lag_max',\n",
+    "                    'merchant_id_nunique',\n",
+    "                    'merchant_category_id_nunique',\n",
+    "                    'state_id_nunique',\n",
+    "                    'city_id_nunique',\n",
+    "                    'subsector_id_nunique',\n",
+    "                    'authorized_flag_Y_ratio',\n",
+    "                    'category_1_Y_ratio',\n",
+    "                    'category_2_1.0_ratio',\n",
+    "                    'category_2_2.0_ratio',\n",
+    "                    'category_2_3.0_ratio',\n",
+    "                    'category_2_4.0_ratio',\n",
+    "                    'category_2_5.0_ratio',\n",
+    "                    'category_3_A_ratio',\n",
+    "                    'category_3_B_ratio',\n",
+    "                    'category_3_C_ratio']\n",
+    "dep_var = 'target'"
    ]
   },
   {
@@ -592,7 +670,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn.fit_one_cycle(3, 1e-3, wd=0.2)"
+    "learn.fit_one_cycle(1, 1e-3, wd=0.5)"
    ]
   },
   {
@@ -741,7 +819,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Later, I think we can do exactly the same operations for the
new_merchant_transactions table, as well.

I also noticed that a weight decay of 0.5 was better for avoiding
overfitting. In general, I believe one should use a higher weight
decay the more features one has.