### PR TITLE
Callable clean merchants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,15 @@ ifneq (,$(missingunzipped))
 	chmod 0644 $@/*.csv
 endif
 
+data/processed: data/unzipped
+ifeq (, $(wildcard data/processed))
+	mkdir $@
+endif
+
+data/processed/merchants.csv: data/processed
+	python clean_merchants.py $@
+
+
 # call 'make print-{VARIABLE}' to print make variable value
 # e.g.: make print-missingunzipped
 print-%: ; @echo $* = $($*)

--- a/clean_merchants.py
+++ b/clean_merchants.py
@@ -30,7 +30,7 @@ def sum_triples(triples):
         return 'N'
 
 
-def clean_merchants():
+def clean_merchants(filename = ''):
     merchants_df = pd.read_csv('data/unzipped/merchants.csv')
 
     # There are a lot (over 100000) merchants with incomplete city and state data.
@@ -92,4 +92,16 @@ def clean_merchants():
     aggregated_df['most_recent_sales_range'] = aggregated_df['most_recent_sales_range'].astype(cat_most_recent)
     aggregated_df['most_recent_purchases_range'] = aggregated_df['most_recent_purchases_range'].astype(cat_most_recent)
 
+    if filename != '':
+        aggregated_df.to_csv(filename)
+
     return aggregated_df
+
+if __name__=="__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Clean merchants data.")
+    parser.add_argument('outfile', type=str, help='Filename of the result csv.')
+    args = vars(parser.parse_args())
+
+    clean_merchants(args['outfile'])


### PR DESCRIPTION
Add Makefile target to write the cleaned merchant data to data/processed/merchants.csv.

Running clean_merchants takes quite a while, so it might be nice to save the result.

Call make data/processed/merchants.csv execute the script.
Nice shells like zsh offer make target tab completion.